### PR TITLE
Update spack recipes

### DIFF
--- a/.github/workflows/ghex.yml
+++ b/.github/workflows/ghex.yml
@@ -3,8 +3,8 @@ name: test-ghex
 on:
   push:
   pull_request:
-    branches:
-      - main
+    # branches:
+    #   - main
 
 jobs:
   spack-install:

--- a/.github/workflows/hwmalloc.yml
+++ b/.github/workflows/hwmalloc.yml
@@ -3,8 +3,8 @@ name: test-hwmalloc
 on:
   push:
   pull_request:
-    branches:
-      - main
+    # branches:
+    #   - main
 
 jobs:
   spack-install:

--- a/.github/workflows/oomph.yml
+++ b/.github/workflows/oomph.yml
@@ -3,8 +3,8 @@ name: test-oomph
 on:
   push:
   pull_request:
-    branches:
-      - main
+    # branches:
+    #   - main
 
 jobs:
   spack-install:

--- a/packages/ghex/package.py
+++ b/packages/ghex/package.py
@@ -58,13 +58,12 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
             self.define_from_variant("GHEX_USE_XPMEM", "xpmem"),
             self.define_from_variant("GHEX_BUILD_PYTHON_BINDINGS", "python"),
             self.define("GHEX_WITH_TESTING", self.run_tests),
-            self.define("MPIEXEC_PREFLAGS", "--oversubscribe"),
         ]
 
         if self.spec.satisfies("+python"):
             args.append(self.define("GHEX_PYTHON_LIB_PATH", python_platlib))
 
-        if self.run_tests:
+        if self.run_tests and self.spec.satisfies("^openmpi"):
             args.append("-DMPIEXEC_PREFLAGS=--oversubscribe")
 
         if "+cuda" in spec and spec.variants["cuda_arch"].value != "none":

--- a/packages/ghex/package.py
+++ b/packages/ghex/package.py
@@ -12,8 +12,7 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
     version("0.4.1", tag="v0.4.1", submodules=True)
     version("0.4.0", tag="v0.4.0", submodules=True)
     version("0.3.0", tag="v0.3.0", submodules=True)
-    # for dev-build
-    version("develop")
+    version("master", branch="master", submodules=True)
 
     variant(
         "backend", default="mpi", description="Transport backend",

--- a/packages/ghex/package.py
+++ b/packages/ghex/package.py
@@ -1,11 +1,11 @@
 from spack.package import *
 
-class Ghex(CMakePackage, CudaPackage, ROCmPackage):
-    """"GHEX is a generic halo-exchange library."""
 
-    homepage="https://github.com/ghex-org/GHEX"
+class Ghex(CMakePackage, CudaPackage, ROCmPackage):
+    """GHEX is a generic halo-exchange library."""
+
+    homepage = "https://github.com/ghex-org/GHEX"
     url = "https://github.com/ghex-org/GHEX/archive/refs/tags/v0.3.0.tar.gz"
-    
     git = "https://github.com/ghex-org/GHEX.git"
     maintainers = ["boeschf"]
 
@@ -80,4 +80,3 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
             args.append(self.define("CMAKE_HIP_ARCHITECTURES", arch_str))
 
         return args
-        

--- a/packages/ghex/package.py
+++ b/packages/ghex/package.py
@@ -63,7 +63,7 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
             args.append(self.define("GHEX_PYTHON_LIB_PATH", python_platlib))
 
         if self.run_tests and self.spec.satisfies("^openmpi"):
-            args.append("-DMPIEXEC_PREFLAGS=--oversubscribe")
+            args.append(self.define("MPIEXEC_PREFLAGS", "--oversubscribe"))
 
         if "+cuda" in spec and spec.variants["cuda_arch"].value != "none":
             arch_str = ";".join(spec.variants["cuda_arch"].value)

--- a/packages/ghex/package.py
+++ b/packages/ghex/package.py
@@ -34,6 +34,8 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("oomph+rocm", when="+rocm")
     depends_on("oomph@0.3:", when="@0.3:")
 
+    conflicts("+cuda+rocm")
+
     with when("+python"):
         extends("python")
         depends_on("python@3.7:", type="build")

--- a/packages/ghex/package.py
+++ b/packages/ghex/package.py
@@ -68,9 +68,16 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
         if "+cuda" in spec and spec.variants["cuda_arch"].value != "none":
             arch_str = ";".join(spec.variants["cuda_arch"].value)
             args.append(self.define("CMAKE_CUDA_ARCHITECTURES", arch_str))
+            args.append(self.define("GHEX_USE_GPU", True))
+            args.append(self.define("GHEX_GPU_TYPE", "CUDA"))
 
         if "+rocm" in spec and spec.variants["amdgpu_target"].value != "none":
             arch_str = ";".join(spec.variants["amdgpu_target"].value)
             args.append(self.define("CMAKE_HIP_ARCHITECTURES", arch_str))
+            args.append(self.define("GHEX_USE_GPU", True))
+            args.append(self.define("GHEX_GPU_TYPE", "AMD"))
+
+        if self.spec.satisfies("~cuda~rocm"):
+            args.append(self.define("GHEX_USE_GPU", False))
 
         return args

--- a/packages/ghex/package.py
+++ b/packages/ghex/package.py
@@ -25,7 +25,6 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("mpi")
     depends_on("boost")
     depends_on("xpmem", when="+xpmem", type=("build", "run"))
-    depends_on("googletest", type="test")
 
     depends_on("oomph")
     for backend in backends:
@@ -52,8 +51,8 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
         args = [
             self.define("GHEX_USE_BUNDLED_LIBS", True),
             self.define("GHEX_USE_BUNDLED_GRIDTOOLS", True),
+            self.define("GHEX_USE_BUNDLED_GTEST", self.run_tests),
             self.define("GHEX_USE_BUNDLED_OOMPH", False),
-            self.define("GHEX_USE_BUNDLED_GTEST", False),
             self.define("GHEX_TRANSPORT_BACKEND", spec.variants["backend"].value.upper()),
             self.define_from_variant("GHEX_USE_XPMEM", "xpmem"),
             self.define_from_variant("GHEX_BUILD_PYTHON_BINDINGS", "python"),

--- a/packages/ghex/package.py
+++ b/packages/ghex/package.py
@@ -9,6 +9,7 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
     git = "https://github.com/ghex-org/GHEX.git"
     maintainers = ["boeschf"]
 
+    version("0.4.1", tag="v0.4.1", submodules=True)
     version("0.4.0", tag="v0.4.0", submodules=True)
     version("0.3.0", tag="v0.3.0", submodules=True)
     # for dev-build

--- a/packages/ghex/package.py
+++ b/packages/ghex/package.py
@@ -34,19 +34,18 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("oomph+rocm", when="+rocm")
     depends_on("oomph@0.3:", when="@0.3:")
 
-    extends("python", when="+python")
-    depends_on("python@3.7:", when="+python", type="build")
-    depends_on("py-pip", when="+python", type="build")
-    depends_on("py-pybind11", when="+python", type="build")
-    depends_on("py-mpi4py", when="+python", type=("build", "run"))
-    depends_on("py-numpy", when="+python", type=("build", "run"))
+    with when("+python"):
+        extends("python")
+        depends_on("python@3.7:", type="build")
+        depends_on("py-pip", type="build")
+        depends_on("py-pybind11", type="build")
+        depends_on("py-mpi4py", type=("build", "run"))
+        depends_on("py-numpy", type=("build", "run"))
 
-    depends_on("py-pytest", when="+python", type=("test"))
+        depends_on("py-pytest", when="+python", type=("test"))
 
     def cmake_args(self):
         spec = self.spec
-
-        pyexe = spec["python"].command.path
 
         args = [
             self.define("GHEX_USE_BUNDLED_LIBS", True),
@@ -56,10 +55,12 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
             self.define("GHEX_TRANSPORT_BACKEND", spec.variants["backend"].value.upper()),
             self.define_from_variant("GHEX_USE_XPMEM", "xpmem"),
             self.define_from_variant("GHEX_BUILD_PYTHON_BINDINGS", "python"),
-            self.define("GHEX_PYTHON_LIB_PATH", python_platlib),
             self.define("GHEX_WITH_TESTING", self.run_tests),
             self.define("MPIEXEC_PREFLAGS", "--oversubscribe"),
         ]
+
+        if self.spec.satisfies("+python"):
+            args.append(self.define("GHEX_PYTHON_LIB_PATH", python_platlib))
 
         if self.run_tests:
             args.append("-DMPIEXEC_PREFLAGS=--oversubscribe")

--- a/packages/ghex/package.py
+++ b/packages/ghex/package.py
@@ -21,7 +21,7 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
     variant("xpmem", default=False, description="Use xpmem shared memory")
     variant("python", default=True, description="Build Python bindings")
 
-    depends_on("cmake@3.21:")
+    depends_on("cmake@3.21:", type="build")
     depends_on("mpi")
     depends_on("boost")
     depends_on("xpmem", when="+xpmem", type=("build", "run"))

--- a/packages/hwmalloc/package.py
+++ b/packages/hwmalloc/package.py
@@ -1,9 +1,10 @@
 from spack.package import *
 
-class Hwmalloc(CMakePackage, CudaPackage, ROCmPackage):
-    """"HWMALLOC is a allocator which supports memory registration for e.g. remote memory access"""
 
-    homepage="https://github.com/ghex-org/hwmalloc"
+class Hwmalloc(CMakePackage, CudaPackage, ROCmPackage):
+    """HWMALLOC is a allocator which supports memory registration for e.g. remote memory access"""
+
+    homepage = "https://github.com/ghex-org/hwmalloc"
     url = "https://github.com/ghex-org/hwmalloc/archive/refs/tags/v0.3.0.tar.gz"
     git = "https://github.com/ghex-org/hwmalloc.git"
     maintainers = ["boeschf"]
@@ -12,14 +13,16 @@ class Hwmalloc(CMakePackage, CudaPackage, ROCmPackage):
     version("0.2.0", sha256="734758a390a3258b86307e4aef50a7ca2e5d0e2e579f18aeefcd05397e114419")
     version("0.1.0", sha256="06e9bfcef0ecce4d19531ccbe03592b502d1281c7a092bc0ff51ca187899b21c")
     version("master", branch="master")
-    # for dev-build
-    version("develop")
 
     depends_on("numactl", type=("build", "run"))
     depends_on("boost", type=("build"))
     depends_on("cmake@3.19:", type="build")
 
-    variant("numa-throws", default=False, description="True if numa_tools may throw during initialization")
+    variant(
+        "numa-throws",
+        default=False,
+        description="True if numa_tools may throw during initialization",
+    )
     variant("numa-local", default=True, description="Use numa_tools for local node allocations")
     variant("logging", default=False, description="print logging info to cerr")
 
@@ -34,10 +37,12 @@ class Hwmalloc(CMakePackage, CudaPackage, ROCmPackage):
         ]
 
         if "+cuda" in self.spec:
-            args.append("-DHWMALLOC_ENABLE_DEVICE=ON")
-            args.append("-DHWMALLOC_DEVICE_RUNTIME=cuda")
+            args.append(self.define("HWMALLOC_ENABLE_DEVICE", True))
+            args.append(self.define("HWMALLOC_DEVICE_RUNTIME", "cuda"))
         elif "+rocm" in self.spec:
-            args.append("-DHWMALLOC_ENABLE_DEVICE=ON")
-            args.append("-DHWMALLOC_DEVICE_RUNTIME=hip")
+            args.append(self.define("HWMALLOC_ENABLE_DEVICE", True))
+            args.append(self.define("HWMALLOC_DEVICE_RUNTIME", "hip"))
+        else:
+            args.append(self.define("HWMALLOC_ENABLE_DEVICE", False))
 
         return args

--- a/packages/oomph/package.py
+++ b/packages/oomph/package.py
@@ -1,9 +1,10 @@
 from spack.package import *
 
-class Oomph(CMakePackage, CudaPackage, ROCmPackage):
-    """"Oomph is a non-blocking callback-based point-to-point communication library."""
 
-    homepage="https://github.com/ghex-org/oomph"
+class Oomph(CMakePackage, CudaPackage, ROCmPackage):
+    """Oomph is a non-blocking callback-based point-to-point communication library."""
+
+    homepage = "https://github.com/ghex-org/oomph"
     url = "https://github.com/ghex-org/oomph/archive/refs/tags/v0.2.0.tar.gz"
     git = "https://github.com/ghex-org/oomph.git"
     maintainers = ["boeschf"]
@@ -21,10 +22,20 @@ class Oomph(CMakePackage, CudaPackage, ROCmPackage):
 
     variant("fortran-bindings", default=False, description="Build Fortran bindings")
     with when("+fortran-bindings"):
-        variant("fortran-fp", default="float", description="Floating point type", values=("float", "double"), multi=False)
+        variant(
+            "fortran-fp",
+            default="float",
+            description="Floating point type",
+            values=("float", "double"),
+            multi=False,
+        )
         variant("fortran-openmp", default=True, description="Compile with OpenMP")
 
-    variant("enable-barrier", default=True, description="Enalbe thread barrier (disable for task based runtime)")
+    variant(
+        "enable-barrier",
+        default=True,
+        description="Enable thread barrier (disable for task based runtime)",
+    )
 
     depends_on("hwmalloc+cuda", when="+cuda")
     depends_on("hwmalloc+rocm", when="+rocm")
@@ -34,11 +45,8 @@ class Oomph(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("ucx+thread_multiple")
         depends_on("ucx+cuda", when="+cuda")
         depends_on("ucx+rocm", when="+rocm")
-        #depends_on("ucx", when="~cuda~rocm")
-        variant("use-pmix", default="False",
-            description="Use PMIx to establisch out-of-band setup")
-        variant("use-spin-lock", default="False",
-            description="Use pthread spin locks")
+        variant("use-pmix", default="False", description="Use PMIx to establish out-of-band setup")
+        variant("use-spin-lock", default="False", description="Use pthread spin locks")
         depends_on("pmix", when="+use-pmix")
 
     with when("backend=libfabric"):

--- a/packages/oomph/package.py
+++ b/packages/oomph/package.py
@@ -63,7 +63,7 @@ class Oomph(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("mpi")
     depends_on("boost+thread")
 
-    depends_on("googletest", type="test")
+    depends_on("googletest", type=("build","test"))
 
     patch("install_0.2.patch", when="@:0.2.0", level=1)
     patch("install_0.3.patch", when="@0.3.0", level=1)
@@ -80,8 +80,8 @@ class Oomph(CMakePackage, CudaPackage, ROCmPackage):
             self.define("OOMPH_USE_BUNDLED_LIBS", False),
         ]
 
-        if self.run_tests:
-            args.append("-DMPIEXEC_PREFLAGS=--oversubscribe")
+        if self.run_tests and self.spec.satisfies("^openmpi"):
+            args.append(self.define("MPIEXEC_PREFLAGS", "--oversubscribe"))
 
         if self.spec.variants["fortran-bindings"].value == True:
             args.append(self.define("OOMPH_FORTRAN_FP", self.spec.variants["fortran-fp"].value))

--- a/packages/oomph/package.py
+++ b/packages/oomph/package.py
@@ -13,9 +13,7 @@ class Oomph(CMakePackage, CudaPackage, ROCmPackage):
     version("0.2.0", sha256="135cdb856aa817c053b6af1617869dbcd0ee97d34607e78874dd775ea389434e")
     version("0.1.0", sha256="0ff36db0a5f30ae1bb02f6db6d411ea72eadd89688c00f76b4e722bd5a9ba90b")
     version("main", branch="main")
-    # for dev-build
-    version("develop")
-    
+
     backends = ("mpi", "ucx", "libfabric")
     variant(
         "backend", default="mpi", description="Transport backend", values=backends, multi=False


### PR DESCRIPTION
Not extensively tested, but `spack install --test=root --verbose oomph` and `spack install --test=root --verbose ghex` work. May have some subjective changes, and I'm not dead set on them so happy to remove parts that you don't like.

- A lot of cosmetic changes: format with black, use `self.define` consistently, remove some stray `"` etc.
- Slight refactoring of variants/CMake options handling to reduce duplication.
- Adds ghex 0.4.1.
- `--oversubscribe` only works with OpenMPI's `mpiexec`, so only use it there.
- This is a bit more explicit about setting some CMake options, e.g. explicitly turning off GPu support when it's not requested.